### PR TITLE
Added editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Editor config is a tool that allows the standardisation of things that different editors and different developers prefer.

For example tabs vs spaces. The developer can use whichever they prefer and the editor config will tell the editor how to handle them so that everyone on the team will see the same thing and not have strange behaviour where formatting is messed up because someone used tabs and your editor displays them strangely.